### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
+++ b/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
@@ -117,7 +117,8 @@ namespace VideoSharingService.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Login([FromBody] LoginDTO userDTO)
         {
-            _logger.LogInformation($"Login attempt for {userDTO.Email}");
+            var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
+            _logger.LogInformation($"Login attempt for {sanitizedEmail}");
             if (!ModelState.IsValid)
             {
                 _logger.LogError($"Invalid post attempt {nameof(Login)}");


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/YTVidShare/security/code-scanning/2](https://github.com/NafisianCastle/YTVidShare/security/code-scanning/2)

The problem should be fixed by sanitizing `userDTO.Email` before writing it to the log. For log files that are stored as plain text, the best practice is to remove or replace new line characters (`\r`, `\n`) and other potentially problematic control characters from user input before logging. This can be done using `String.Replace` for `\r` and `\n` or a small sanitization helper.

In the file `YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs`, line 120 should be updated so the email address is sanitized before logging. This can be achieved by replacing line breaks in `userDTO.Email` with an empty string. Since this pattern is only needed here, and for simplicity, the call to `Replace('\r', '')` and `Replace('\n', '')` can be chained inline.

No new methods or utility definitions are strictly necessary for a single usage, but a helper function could be created if this were common across many places.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
