### PR TITLE
Potential fix for code scanning alert no. 3: Exposure of private information

### DIFF
--- a/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
+++ b/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
@@ -20,6 +20,20 @@ namespace VideoSharingService.Controllers
     [ApiController]
     public class UserController : ControllerBase
     {
+        // Mask the email address for logging purposes to avoid exposing private info
+        private string MaskEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email) || !email.Contains("@"))
+                return "unknown";
+            
+            var parts = email.Split('@');
+            var prefix = parts[0];
+            var domain = parts[1];
+            var maskedPrefix = prefix.Length <= 2
+                ? prefix.Substring(0, 1) + "***"
+                : prefix.Substring(0, 1) + new string('*', prefix.Length - 2) + prefix.Substring(prefix.Length - 1, 1);
+            return $"{maskedPrefix}@{domain}";
+        }
         private readonly IUnitOfWork _unitOfWork;
         private readonly ILogger<UserController> _logger;
         private readonly IMapper _mapper;
@@ -118,7 +132,7 @@ namespace VideoSharingService.Controllers
         public async Task<IActionResult> Login([FromBody] LoginDTO userDTO)
         {
             var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
-            _logger.LogInformation($"Login attempt for {sanitizedEmail}");
+            _logger.LogInformation($"Login attempt for {MaskEmail(sanitizedEmail)}");
             if (!ModelState.IsValid)
             {
                 _logger.LogError($"Invalid post attempt {nameof(Login)}");


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/YTVidShare/security/code-scanning/3](https://github.com/NafisianCastle/YTVidShare/security/code-scanning/3)

The problem lies in logging the full, potentially sensitive user email address in the login attempt log message. To fix this:

- Mask the email address before logging it, e.g., log only a portion (such as "Login attempt for u***@domain.com") or remove altogether and log a generic "Login attempt" message.
- This change should occur on line 121, where the log statement uses `sanitizedEmail`.
- Add a small utility function within the controller to mask emails, or directly mask in the log statement.
- No external libraries are strictly necessary. You can implement a short method to mask email addresses inline within the file.
- The scope is only the log message on login (line 121). Registration logs (line 84) are not included in the detected error and do not need to be changed unless desired for consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
