### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
+++ b/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
@@ -95,7 +95,8 @@ namespace VideoSharingService.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Register([FromBody] CreateUserDTO userDTO)
         {
-            _logger.LogInformation($"Registration attempt for {userDTO.Email}");
+            var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
+            _logger.LogInformation($"Registration attempt for {sanitizedEmail}");
             if (!ModelState.IsValid)
             {
                 _logger.LogError($"Invalid post attempt {nameof(Register)}");


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/YTVidShare/security/code-scanning/1](https://github.com/NafisianCastle/YTVidShare/security/code-scanning/1)

To eliminate log forging risks, the user-provided email logged at line 98 should be sanitized to remove new-line (and carriage return) characters before logging. The most direct fix is to use `.Replace("\r", "").Replace("\n", "")` on the string, similar to the code's sanitization on line 134 in the Login handler. This ensures no new log entries can be forged via input containing those characters.

To implement, in `Register`, before logging the email, assign
```csharp
var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
```
and log the sanitized value in place of `userDTO.Email`. Edits are limited to the file and method shown.

Optionally, if email masking is used elsewhere for privacy, you may also refactor to log a masked (but sanitized) version of the email. However, the primary risk addressed is the log forging vector, not privacy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
