### PR TITLE
Potential fix for code scanning alert no. 6: Exposure of private information

### DIFF
--- a/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
+++ b/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
@@ -148,7 +148,7 @@ namespace VideoSharingService.Controllers
         public async Task<IActionResult> Login([FromBody] LoginDTO userDTO)
         {
             var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
-            _logger.LogInformation($"Login attempt for email hash {HashEmail(sanitizedEmail)}");
+            _logger.LogInformation("Login attempt received.");
             if (!ModelState.IsValid)
             {
                 _logger.LogError($"Invalid post attempt {nameof(Login)}");


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/YTVidShare/security/code-scanning/6](https://github.com/NafisianCastle/YTVidShare/security/code-scanning/6)

To fix this vulnerability, avoid logging user emails, even in hashed form. It is sufficient to log "Login attempt" or, if correlation is needed, use a randomly generated identifier per session or request that cannot be mapped back to the user. In this instance, update line 151 in `UserController.cs` to remove reference to the email hash, changing it to a generic log statement (e.g., just "Login attempt received"). No need to introduce a new method or imports; simply replace or change the log statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
