### PR TITLE
Potential fix for code scanning alert no. 5: Exposure of private information

### DIFF
--- a/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
+++ b/YTVidShareBackend/VideoSharingService/VideoSharingService/Controllers/UserController.cs
@@ -111,7 +111,7 @@ namespace VideoSharingService.Controllers
         public async Task<IActionResult> Register([FromBody] CreateUserDTO userDTO)
         {
             var sanitizedEmail = userDTO.Email?.Replace("\r", "").Replace("\n", "");
-            _logger.LogInformation($"Registration attempt for {sanitizedEmail}");
+            _logger.LogInformation("Registration attempt received.");
             if (!ModelState.IsValid)
             {
                 _logger.LogError($"Invalid post attempt {nameof(Register)}");


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/YTVidShare/security/code-scanning/5](https://github.com/NafisianCastle/YTVidShare/security/code-scanning/5)

To fix this problem, avoid logging sensitive information like email addresses in application logs. Instead of writing the user's email address to logs on registration attempts, you can log a more generic message, such as "Registration attempt received" without including the identifiable email. If logging some information to correlate with the specific registration is genuinely required, you could instead log an anonymized or hashed representation, but only if truly justified and compliant with policies. 

To implement the fix, only line 114 in `UserController.cs` needs changing: update the `_logger.LogInformation` statement to remove the inclusion of `sanitizedEmail`, and log a generic message instead (e.g., `"Registration attempt received."`). No imports or method definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
